### PR TITLE
Tournament create and join view

### DIFF
--- a/endpoints.md
+++ b/endpoints.md
@@ -60,8 +60,11 @@ Deleted `/api/user/friendships`, reworked `/api/user/friends` endpoint, updated 
 
 
 ### `/api/tournament`
-| Endpoint | Supported methods | Required input | Return codes | Notes |
-| :--- |---|:---| :---:| :---: |
-| `/create`|POST|`tournament_name`(optional)<br>`player_tmp_username`(optional)|200<br>400<br>404|Creates a tournament and player_tournament database entries
-| `/join`|POST|`tournament_name`(optional)<br>`player_tmp_username`(optional)|200<br>403<br>404|If `tournament_name` -> joins the exact tournament or asks the user to create one<br> If no `tournament_name` -> joins the first tournament with a free spot of asks the user to create one
-| `/ws/<int:tournament_id>/`|non-HTTP|`?uuid=`|Connected<br>Disconnected|Matchmaking for tournament. Returns match_id for pairs of users.
+| Endpoint | Supported methods | Required input | Return codes | Return values | Notes |
+| :--- |---|:---| :---:| :---: | :---: |
+|`/create`|POST|`tournament_name`(optional)<br>`player_tmp_username`(optional)|201<br>400<br>403<br>404|`tournament` object with all info from the database, including a list of `players` in the tournament |Creates a tournament and player_tournament database entries.
+|`/join/<int:tournament_id>/`|POST|`player_tmp_username`(optional)|201<br>400<br>403<br>404|`tournament` object with all info from the database, including a list of `players` in the tournament |Adds `player` into a tournament based on `tournamend_id` in URL.
+|`/join/cancel/<int:tournament_id>/`|POST||200<br>403<br>404|`tournament` object with all info from the database, including a list of `players` in the tournament|Deletes a user from waiting tournament based on `tournament_id` in URL.
+|`/list/waiting` | GET ||200<br>404|list object of all waiting tournaments, including free spaces for players to join ||
+|`/list/for-player` | GET || 200<br>404| list object of all tournaments for a particular user ||
+|`/ws/<int:tournament_id>/`|non-HTTP|`?uuid=`|Connected<br>Disconnected|`match_id` if there is a match to play for the particular `player`|Matchmaking for tournament.

--- a/tournament/api/serializers.py
+++ b/tournament/api/serializers.py
@@ -61,22 +61,25 @@ class FriendshipListSerializer(serializers.ModelSerializer):
 			return "ON"
 		return "OFF"
 	
-class TournamentSerializer(serializers.ModelSerializer):
-	class Meta:
-		model = Tournament
-		fields = '__all__'
-	
 class PlayerTournamentSerializer(serializers.ModelSerializer):
 	class Meta:
 		model = PlayerTournament
 		fields = '__all__'
 
-class WaitingTournamentSerializer(serializers.ModelSerializer):
-    free_spaces = serializers.SerializerMethodField()
+class TournamentSerializer(serializers.ModelSerializer):
+    players = PlayerTournamentSerializer(source='playertournament_set', many=True, read_only=True)
 
     class Meta:
         model = Tournament
-        fields = ['id', 'name', 'status', 'free_spaces']
+        fields = ['id', 'name', 'status', 'players']
+	
+class WaitingTournamentSerializer(serializers.ModelSerializer):
+    free_spaces = serializers.SerializerMethodField()
+    players = PlayerTournamentSerializer(source='playertournament_set', many=True, read_only=True)
+
+    class Meta:
+        model = Tournament
+        fields = ['id', 'name', 'status', 'free_spaces', 'players']
 
     def get_free_spaces(self, obj):
         player_count = PlayerTournament.objects.filter(tournament=obj).count()

--- a/tournament/tournament/urls.py
+++ b/tournament/tournament/urls.py
@@ -24,9 +24,10 @@ urlpatterns = [
 	path('api/tournament/create', views.CreateTournamentView.as_view(), name='create-tournament'),
 	path('api/tournament/join/<int:tournament_id>/', views.JoinTournamentView.as_view(), name='join-tournament'),
 	path('api/tournament/join/cancel/<int:tournament_id>/', views.CancelJoinTournamentView.as_view(), name='cancel-join-tournament'),
-	path('api/tournament/list', views.TournamentListView.as_view(), name='all-debug-tournaments'),
-	path('api/tournament/player/list', views.PlayerTournamentListView.as_view(), name='list-playertournaments'),
-	path('api/tournament/debug/all', views.AllTournamentListView.as_view(), name='all-debug-tournaments'),
+	path('api/tournament/list/waiting', views.WaitingTournamentsListView.as_view(), name='list-waiting-tournaments'),
+	path('api/tournament/list/player', views.TournamentsListOfPlayerView.as_view(), name='list-tournaments-of-player'),
+	path('api/tournament/debug/playertournament/all', views.PlayerTournamentListView.as_view(), name='debug-list-playertournaments'),
+	path('api/tournament/debug/tournament/all', views.AllTournamentsListView.as_view(), name='debug-list-tournaments'),
 ]  
 urlpatterns += static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
 urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
- Improved create view
  - Cannot create a tournament if has one in WAITING or INPROGRESS status and hasn't finished all matches
- New logic for join view
  - New view to list all waiting tournaments
  - Player joins based on the id selected from the waiting tournaments 
- Added cancel view
  - Player can cancel joining a waiting tournament based on id